### PR TITLE
Shorten title

### DIFF
--- a/scribblings/stxparse-info.scrbl
+++ b/scribblings/stxparse-info.scrbl
@@ -23,8 +23,7 @@
    (require scribble/example)
    (define ev ((make-eval-factory '(racket))))])
 
-@title{stxparse-info : Tracking bound syntax pattern variables with
- @racket[syntax-parse] and @racket[syntax-case]}
+@title{stxparse-info : Tracking bound syntax pattern variables}
 @author[@author+email["Georges Dupéron" "georges.duperon@gmail.com"]]
 
 Source code: @url{https://github.com/jsmaniac/stxparse-info}


### PR DESCRIPTION
The title is currently the longest in Racketland, and doesn’t display well on the TOC of the docs.